### PR TITLE
:green_apple: Fix IOS blank screen bug

### DIFF
--- a/src/misc/handle-apple-install-prompt.js
+++ b/src/misc/handle-apple-install-prompt.js
@@ -1,19 +1,23 @@
 import store from '@/store'
+import { isNil } from 'lodash'
 
-const showPromptForIos =
+const isIosOnBrowser =
   ['iPhone', 'iPad', 'iPod'].includes(navigator.platform) &&
   !window.navigator.standalone
 
-if (showPromptForIos) {
+if (isIosOnBrowser) {
   const now = Date.now()
+  let limitDate = null
   const addToHomeIosPromptLastDate = localStorage.getItem(
     'addToHomeIosPromptLastDate'
   )
-  const limitDate = addToHomeIosPromptLastDate
-    ? new Date(parseInt(addToHomeIosPromptLastDate))
-    : new Date()
-  limitDate.setMonth(addToHomeIosPromptLastDate.getMonth() + 1)
-  if (now >= limitDate.getTime()) {
+
+  if (!isNil(addToHomeIosPromptLastDate)) {
+    limitDate = new Date(parseInt(addToHomeIosPromptLastDate))
+    limitDate.setMonth(limitDate.getMonth() + 1)
+  }
+
+  if (isNil(limitDate) || now >= limitDate.getTime()) {
     store.commit('app/setShowAddToHomeScreenModalForApple', true)
   }
 }


### PR DESCRIPTION
Fix issue : #83 

`handle-apple-install-prompt.js` files was throwing an error because of this line `limitDate.setMonth(addToHomeIosPromptLastDate.getMonth() + 1)`

`addToHomeIosPromptLastDate` is a string and not a Date