### PR TITLE
:bug: Use firebase signin redirect instead of firebase signin with popup

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -66,7 +66,7 @@ export default {
       this.setUser(undefined)
 
       try {
-        await firebase.auth().signInWithPopup(provider)
+        await firebase.auth().signInWithRedirect(provider)
       } catch (err) {
         this.loginError = err
         this.setUser(null)


### PR DESCRIPTION
#82

This PR "partially" resolve the issue. User will not be stuck in a blank page, but it will redirect him to the standalone app, but not logged in (he will have to re authenticate again)