### PR TITLE
:zap: improve loading page

### DIFF
--- a/src/firebase/async-firestore.js
+++ b/src/firebase/async-firestore.js
@@ -1,0 +1,15 @@
+import firebase from 'firebase/app'
+
+let loaded = false
+
+export default async () => {
+  if (!loaded) {
+    await import('firebase/firestore')
+    firebase.firestore().settings({})
+    firebase
+      .firestore()
+      .enablePersistence({ experimentalTabSynchronization: true })
+    loaded = true
+  }
+  return Promise.resolve(firebase.firestore())
+}

--- a/src/firebase/generic-db.js
+++ b/src/firebase/generic-db.js
@@ -1,4 +1,5 @@
 import firebase from 'firebase/app'
+import firestore from './async-firestore'
 import { isNil, keys, cloneDeep } from 'lodash'
 
 export default class GenericDB {
@@ -12,7 +13,7 @@ export default class GenericDB {
    * @param id
    */
   async create(data, id = null) {
-    const collectionRef = firebase.firestore().collection(this.collectionPath)
+    const collectionRef = (await firestore()).collection(this.collectionPath)
     const serverTimestamp = firebase.firestore.FieldValue.serverTimestamp()
 
     const dataToCreate = {
@@ -45,8 +46,7 @@ export default class GenericDB {
    * @param id
    */
   async read(id) {
-    const result = await firebase
-      .firestore()
+    const result = (await firestore())
       .collection(this.collectionPath)
       .doc(id)
       .get()
@@ -63,8 +63,8 @@ export default class GenericDB {
    * Read all documents in the collection following constraints
    * @param constraints
    */
-  readAll(constraints = null) {
-    const collectionRef = firebase.firestore().collection(this.collectionPath)
+  async readAll(constraints = null) {
+    const collectionRef = (await firestore()).collection(this.collectionPath)
     let query = collectionRef
 
     if (constraints) {
@@ -91,8 +91,7 @@ export default class GenericDB {
     const clonedData = cloneDeep(data)
     delete clonedData.id
 
-    await firebase
-      .firestore()
+    await (await firestore())
       .collection(this.collectionPath)
       .doc(id)
       .update({
@@ -107,9 +106,8 @@ export default class GenericDB {
    * Delete a document in the collection
    * @param id
    */
-  delete(id) {
-    return firebase
-      .firestore()
+  async delete(id) {
+    return (await firestore())
       .collection(this.collectionPath)
       .doc(id)
       .delete()

--- a/src/firebase/init.js
+++ b/src/firebase/init.js
@@ -1,5 +1,4 @@
 import firebase from 'firebase/app'
-import 'firebase/firestore'
 import 'firebase/auth'
 
 // The configuration below is not sensitive data. You can serenely add your config here
@@ -13,5 +12,3 @@ const config = {
 }
 
 firebase.initializeApp(config)
-firebase.firestore().settings({})
-firebase.firestore().enablePersistence({ experimentalTabSynchronization: true })


### PR DESCRIPTION
improve loading page. 

I tried to apply this : https://firebase.google.com/docs/projects/pwa#load_services_only_when_theyre_needed

I don't know if it really work. I'm not sure the performance improvment is huge.

Here is a screen of lighthouse comparaison (left before modification / right after modification - don't look at SEO, the difference is caused by netlify) :

![comparatif](https://user-images.githubusercontent.com/4435536/55580988-1b494c00-571c-11e9-80a6-640e4efb7567.png)

@kefranabg , I need your opinion about that.

EDIT : bundlesize — Total bundle size is 150.5KB/255KB (-91.86KB) => The bundle has not really decrease. It is because there is a new chunk asynchronously loaded (dist/chunk-ea7a42bc.js).
```
  File                                      Size             Gzipped

  dist/chunk-vendors.js                     434.65 KiB       141.39 KiB
  dist/chunk-ea7a42bc.js                    384.79 KiB       92.58 KiB
  dist/app.js                               26.86 KiB        9.56 KiB
```