### PR TITLE
Fix/activate link navbar

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -129,10 +129,19 @@ export default {
           cursor: pointer;
         }
 
-        .router-link-exact-active,
-        :hover {
+        @mixin activatedLink() {
           margin-bottom: -2px;
           border-bottom: 2px solid $vue-color;
+        }
+
+        .router-link-active {
+          @include activatedLink;
+        }
+
+        @media (hover) {
+          :hover {
+            @include activatedLink;
+          }
         }
       }
     }


### PR DESCRIPTION
This fix activate link into navbar. I also add a small fix to work better on mobile. Sometime du to a virtual hover on mobile, after clicking into a link it is still showed as activate even it should not be the case.

Example : 
![css-effect-hover](https://user-images.githubusercontent.com/4435536/57569844-8e20a380-73fb-11e9-9e75-de70c68ae4ce.png)

More information about it :
- https://developer.mozilla.org/fr/docs/Web/CSS/@media/hover
- https://drafts.csswg.org/mediaqueries-4/#hover