### PR TITLE
:memo: Add bento-starter demo Play Store link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Want to setup this stack ?
 
 :point_right: [https://bento-starter.firebaseapp.com](https://bento-starter.firebaseapp.com)
 
+Install the PWA demo from Google Play Store :point_right: [bento-starter Google Play Store](https://play.google.com/store/apps/details?id=com.bentostarter.bentostarterdemo)
+
 <br />
 
 <p align="center">


### PR DESCRIPTION
I had some fun publishing bento-starter demo to playstore 😅
I added the link in README => [https://play.google.com/store/apps/details?id=com.bentostarter.bentostarterdemo](https://play.google.com/store/apps/details?id=com.bentostarter.bentostarterdemo)