### PR TITLE
Lighthouse integration to CI (minimum score & budget)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ executors:
   default-executor:
     docker:
       - image: cypress/base:10
+  lighthouse-executor:
+    docker:
+      - image: kporras07/lighthouse-ci
+        environment:
+          - TEST_URL: https://bento-starter.firebaseapp.com/
 
 jobs:
   install-dependencies:
@@ -103,6 +108,14 @@ jobs:
               npm run firebase:deploy:ci
             fi
 
+  lighthouse-audit:
+    executor: lighthouse-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: 'Lighthouse audit'
+          command: lighthouse $TEST_URL --port=9222 --chrome-flags=\"--headless --no-sandbox --disable-gpu\" --output-path=/home/chrome/reports/ci.json --output=json && node ./ci-scripts/analyze_lighthouse.js package.json /home/chrome/reports
 workflows:
   version: 2
   build-and-deploy:
@@ -132,3 +145,6 @@ workflows:
       - deploy:
           requires:
             - check-bundles-sizes
+      - lighthouse-audit:
+          requires:
+            - deploy 

--- a/ci-scripts/analyze_lighthouse.js
+++ b/ci-scripts/analyze_lighthouse.js
@@ -1,0 +1,94 @@
+#!/usr/local/bin/node
+
+const fs = require('fs')
+const path = require('path')
+
+const pkg = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+const requiredScores = pkg.lighthouse.requiredScores
+const reportsDir = process.argv[3]
+const reports = {
+  json: []
+}
+
+fs.readdirSync(reportsDir).forEach(file => {
+  if (path.extname(file) === '.json') {
+    reports.json.push(
+      JSON.parse(fs.readFileSync(path.resolve(reportsDir, file), 'utf8'))
+    )
+    return
+  }
+})
+
+let success = true
+const ciStdout = []
+
+const [scoresAcrossRunsByCategory, budget] = reports.json.reduce(
+  (scores, run) => {
+    // Fetch expected & actual lighthouse scores.
+    Object.keys(requiredScores).forEach(category => {
+      scores[category] = scores[category] || []
+      scores[category].push(run.categories[category].score * 100)
+    })
+
+    // Fetch overbudget items.
+    const budgetsItems =
+      run.audits &&
+      run.audits['performance-budget'] &&
+      run.audits['performance-budget'].details &&
+      run.audits['performance-budget'].details.items
+
+    const budgetReport = budgetsItems
+      ? budgetsItems.reduce((acc, obj) => {
+          if (obj.countOverBudget) {
+            acc[obj.resourceType + '-count'] = `${obj.countOverBudget}`
+          }
+
+          if (obj.sizeOverBudget) {
+            acc[obj.resourceType + '-size'] = `${Math.round(
+              obj.sizeOverBudget / 1024,
+              0
+            )}kb`
+          }
+
+          return acc
+        }, {})
+      : []
+
+    return [scores, budgetReport]
+  },
+  {}
+)
+
+ciStdout.push(
+  '------------------------------------------',
+  `\tLighthouse report`,
+  '------------------------------------------'
+)
+
+// Report scores
+Object.keys(requiredScores).forEach(category => {
+  const requiredOutOf100 = requiredScores[category]
+  const actualBestOutOf100 = Math.max.apply(
+    null,
+    scoresAcrossRunsByCategory[category]
+  )
+
+  if (actualBestOutOf100 < requiredScores[category]) {
+    ciStdout.push(`❌ ${category}: ${actualBestOutOf100}/${requiredOutOf100}`)
+    success = false
+  } else {
+    ciStdout.push(`✅ ${category}: ${actualBestOutOf100}/${requiredOutOf100}`)
+  }
+})
+
+// Report budget
+Object.keys(budget).forEach(budgetItem => {
+  ciStdout.push(`❌ ${budgetItem}: Over budget. (${budget[budgetItem]})`)
+  success = false
+})
+
+console.log(ciStdout.join('\n'))
+
+if (!success) {
+  process.exit(1)
+}

--- a/ci-scripts/budget.json
+++ b/ci-scripts/budget.json
@@ -1,0 +1,32 @@
+[
+    {
+      "resourceSizes": [
+        {
+          "resourceType": "script",
+          "budget": 300
+        },
+        {
+          "resourceType": "image",
+          "budget": 100
+        },
+        {
+          "resourceType": "third-party",
+          "budget": 200
+        },
+        {
+          "resourceType": "total",
+          "budget": 1000
+        }
+      ],
+      "resourceCounts": [
+        {
+          "resourceType": "third-party",
+          "budget": 10
+        },
+        {
+          "resourceType": "total",
+          "budget": 50
+        }
+      ]
+    }
+  ] 

--- a/package.json
+++ b/package.json
@@ -134,5 +134,14 @@
     ],
     "testURL": "http://localhost/",
     "setupTestFrameworkScriptFile": "<rootDir>/tests/unit/setup.js"
+  },
+  "lighthouse": {
+    "requiredScores": {
+      "performance": 80,
+      "accessibility": 90,
+      "best-practices": 80,
+      "seo": 90,
+      "pwa": 100
+    }
   }
 }


### PR DESCRIPTION
**Lighthouse integration to CI.**

- Minimum score requirements can be found in package.json , they can be configured manually.
- Budget can be found in ci-scripts/budget.json, as per Google documentation (default value are from here : https://developers.google.com/web/tools/lighthouse/audits/budgets)
- This adds a last step in circle ci, after deployment. It won't cancel/revert deployment if the audit doesn't pass.
- Unfortunately, Google doesn't have an official Docker image for lighthouse + node, so I found another one on docker hub